### PR TITLE
Disable text selection on action buttons

### DIFF
--- a/styles/popup.css
+++ b/styles/popup.css
@@ -282,6 +282,7 @@ body.dark .day-choice span:before {
 	text-align: center;
 	min-width: 70px;
 	background: rgba(0, 0, 0, .1);
+	user-select: none;
 }
 .action:not(.disabled):hover {
 	background: rgba(0, 0, 0, .2);


### PR DESCRIPTION
This is a small change that disables text selection on `.action` buttons.

Rationale: When using the "Choose your own time" snooze, clicking rapidly on any of the quick action buttons to increment/decrement time values causes the text on the button to be selected. I see no reason for the text in these buttons to be selectable and it doesn't look nice when it happens.

![image](https://user-images.githubusercontent.com/1789096/141255906-ffa20baf-12a4-4d50-bd54-8f35403eb628.png)
